### PR TITLE
add get_num_active_contact_points

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -302,7 +302,11 @@ void initSimBindings(py::module& m) {
       .def("get_existing_joint_motors", &Simulator::getExistingJointMotors,
            "object_id"_a)
       .def("create_motors_for_all_dofs", &Simulator::createMotorsForAllDofs,
-           "object_id"_a, "settings"_a = esp::physics::JointMotorSettings());
+           "object_id"_a, "settings"_a = esp::physics::JointMotorSettings())
+
+      .def("get_num_active_contact_points",
+           &Simulator::getNumActiveContactPoints);
+
   ;
 }
 

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -1120,6 +1120,8 @@ class PhysicsManager {
     return existingArticulatedObjects_.at(objectId)->getMotionType();
   };
 
+  virtual int getNumActiveContactPoints() { return -1; }
+
  protected:
   /** @brief Check that a given object ID is valid (i.e. it refers to an
    * existing object). Terminate the program and report an error if not. This

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -95,7 +95,7 @@ int BulletPhysicsManager::addArticulatedObjectFromURDF(std::string filepath,
     return ID_UNDEFINED;
   }
 
-  //Cr::Utility::Debug() << "Articulated Link Indices: "
+  // Cr::Utility::Debug() << "Articulated Link Indices: "
   //                     << articulatedObject->getLinkIds();
 
   int articulatedObjectID_ = allocateObjectID();
@@ -416,6 +416,26 @@ RaycastResults BulletPhysicsManager::castRay(const esp::geo::Ray& ray,
   }
   results.sortByDistance();
   return results;
+}
+
+int BulletPhysicsManager::getNumActiveContactPoints() {
+  int pointCount = 0;
+  auto* dispatcher = bWorld_->getDispatcher();
+  for (int i = 0; i < dispatcher->getNumManifolds(); i++) {
+    auto* manifold = dispatcher->getManifoldByIndexInternal(i);
+    const btCollisionObject* colObj0 =
+        static_cast<const btCollisionObject*>(manifold->getBody0());
+    const btCollisionObject* colObj1 =
+        static_cast<const btCollisionObject*>(manifold->getBody1());
+
+    // logic copied from btSimulationIslandManager::buildIslands. We want to
+    // count manifold points only if related to non-sleeping bodies.
+    if (((colObj0) && colObj0->getActivationState() != ISLAND_SLEEPING) ||
+        ((colObj1) && colObj1->getActivationState() != ISLAND_SLEEPING)) {
+      pointCount += manifold->getNumContacts();
+    }
+  }
+  return pointCount;
 }
 
 }  // namespace physics

--- a/src/esp/physics/bullet/BulletPhysicsManager.h
+++ b/src/esp/physics/bullet/BulletPhysicsManager.h
@@ -223,6 +223,13 @@ class BulletPhysicsManager : public PhysicsManager {
 
   void removeP2PConstraint(int p2pId);
 
+  // The number of contact points that were active during the last step. An
+  // object resting on another object will involve several active contact
+  // points. Once both objects are asleep, the contact points are inactive. This
+  // count can be used as a metric for the complexity/cost of collision-handling
+  // in the current scene.
+  int getNumActiveContactPoints() override;
+
   int nextP2PId_ = 0;
   std::map<int, btMultiBodyPoint2Point*> articulatedP2ps;
   std::map<int, btPoint2PointConstraint*> rigidP2ps;

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -762,6 +762,10 @@ class Simulator {
    */
   core::Random::ptr random() { return random_; }
 
+  int getNumActiveContactPoints() {
+    return physicsManager_->getNumActiveContactPoints();
+  }
+
  protected:
   Simulator(){};
 


### PR DESCRIPTION
## Motivation and Context

add `get_num_active_contact_points`. The number of contact points that were active during the last step. An object resting on another object will involve several active contact points. Once both objects are asleep, the contact points are inactive. This count can be used as a metric for the complexity/cost of collision-handling in the current scene.

## How Has This Been Tested

Ad hoc testing in Hab-sim viewer and `p-viz-plan` training episodes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
