### PR TITLE
P2P and Fixed Constraints and CollisionGroup API

### DIFF
--- a/src/esp/bindings/SimBindings.cpp
+++ b/src/esp/bindings/SimBindings.cpp
@@ -50,77 +50,84 @@ void initSimBindings(py::module& m) {
       .def(py::self != py::self);
 
   // ==== Simulator ====
-  py::class_<Simulator, Simulator::ptr>(m, "Simulator")
-      .def(py::init<const SimulatorConfiguration&>())
-      .def("get_active_scene_graph", &Simulator::getActiveSceneGraph,
-           R"(PYTHON DOES NOT GET OWNERSHIP)",
-           py::return_value_policy::reference)
-      .def("get_active_semantic_scene_graph",
-           &Simulator::getActiveSemanticSceneGraph,
-           R"(PYTHON DOES NOT GET OWNERSHIP)",
-           py::return_value_policy::reference)
-      .def_property_readonly("semantic_scene", &Simulator::getSemanticScene, R"(
+  py::
+      class_<Simulator, Simulator::ptr>(m, "Simulator")
+          .def(py::init<const SimulatorConfiguration&>())
+          .def("get_active_scene_graph", &Simulator::getActiveSceneGraph,
+               R"(PYTHON DOES NOT GET OWNERSHIP)",
+               py::return_value_policy::reference)
+          .def("get_active_semantic_scene_graph",
+               &Simulator::getActiveSemanticSceneGraph,
+               R"(PYTHON DOES NOT GET OWNERSHIP)",
+               py::return_value_policy::reference)
+          .def_property_readonly("semantic_scene", &Simulator::getSemanticScene,
+                                 R"(
         The semantic scene graph
 
         .. note-warning::
 
             Not available for all datasets
             )")
-      .def_property_readonly("renderer", &Simulator::getRenderer)
-      .def("seed", &Simulator::seed, "new_seed"_a)
-      .def("reconfigure", &Simulator::reconfigure, "configuration"_a)
-      .def("reset", &Simulator::reset)
-      .def("close", &Simulator::close)
-      .def_property("pathfinder", &Simulator::getPathFinder,
-                    &Simulator::setPathFinder)
-      .def_property(
-          "navmesh_visualization", &Simulator::isNavMeshVisualizationActive,
-          &Simulator::setNavMeshVisualization,
-          R"(Enable or disable wireframe visualization of current pathfinder's NavMesh.)")
-      .def_property_readonly("gpu_device", &Simulator::gpuDevice)
-      .def_property_readonly("random", &Simulator::random)
-      .def_property("frustum_culling", &Simulator::isFrustumCullingEnabled,
-                    &Simulator::setFrustumCullingEnabled,
-                    R"(Enable or disable the frustum culling)")
-      /* --- Physics functions --- */
-      /* --- Template Manager accessors --- */
-      .def(
-          "get_asset_template_manager", &Simulator::getAssetAttributesManager,
-          pybind11::return_value_policy::reference,
-          R"(Get the Simulator's AssetAttributesManager instance for configuring primitive asset templates.)")
-      .def(
-          "get_object_template_manager", &Simulator::getObjectAttributesManager,
-          pybind11::return_value_policy::reference,
-          R"(Get the Simulator's ObjectAttributesManager instance for configuring object templates.)")
-      .def(
-          "get_physics_template_manager",
-          &Simulator::getPhysicsAttributesManager,
-          pybind11::return_value_policy::reference,
-          R"(Get the Simulator's PhysicsAttributesManager instance for configuring PhysicsManager templates.)")
-      .def(
-          "get_stage_template_manager", &Simulator::getStageAttributesManager,
-          pybind11::return_value_policy::reference,
-          R"(Get the Simulator's StageAttributesManager instance for configuring simulation stage templates.)")
-      .def(
-          "get_physics_simulation_library",
-          &Simulator::getPhysicsSimulationLibrary,
-          R"(Query the physics library implementation currently configured by this Simulator instance.)")
-      /* --- Object instancing and access --- */
-      .def(
-          "add_object", &Simulator::addObject, "object_lib_id"_a,
-          "attachment_node"_a = nullptr,
-          "light_setup_key"_a = assets::ResourceManager::DEFAULT_LIGHTING_KEY,
-          "scene_id"_a = 0,
-          R"(Instance an object into the scene via a template referenced by library id. Optionally attach the object to an existing SceneNode and assign its initial LightSetup key.)")
-      .def(
-          "add_object_by_handle", &Simulator::addObjectByHandle,
-          "object_lib_handle"_a, "attachment_node"_a = nullptr,
-          "light_setup_key"_a = assets::ResourceManager::DEFAULT_LIGHTING_KEY,
-          "scene_id"_a = 0,
-          R"(Instance an object into the scene via a template referenced by its handle. Optionally attach the object to an existing SceneNode and assign its initial LightSetup key.)")
-      .def("remove_object", &Simulator::removeObject, "object_id"_a,
-           "delete_object_node"_a = true, "delete_visual_node"_a = true,
-           "scene_id"_a = 0, R"(
+          .def_property_readonly("renderer", &Simulator::getRenderer)
+          .def("seed", &Simulator::seed, "new_seed"_a)
+          .def("reconfigure", &Simulator::reconfigure, "configuration"_a)
+          .def("reset", &Simulator::reset)
+          .def("close", &Simulator::close)
+          .def_property("pathfinder", &Simulator::getPathFinder,
+                        &Simulator::setPathFinder)
+          .def_property(
+              "navmesh_visualization", &Simulator::isNavMeshVisualizationActive,
+              &Simulator::setNavMeshVisualization,
+              R"(Enable or disable wireframe visualization of current pathfinder's NavMesh.)")
+          .def_property_readonly("gpu_device", &Simulator::gpuDevice)
+          .def_property_readonly("random", &Simulator::random)
+          .def_property("frustum_culling", &Simulator::isFrustumCullingEnabled,
+                        &Simulator::setFrustumCullingEnabled,
+                        R"(Enable or disable the frustum culling)")
+          /* --- Physics functions --- */
+          /* --- Template Manager accessors --- */
+          .def(
+              "get_asset_template_manager",
+              &Simulator::getAssetAttributesManager,
+              pybind11::return_value_policy::reference,
+              R"(Get the Simulator's AssetAttributesManager instance for configuring primitive asset templates.)")
+          .def(
+              "get_object_template_manager",
+              &Simulator::getObjectAttributesManager,
+              pybind11::return_value_policy::reference,
+              R"(Get the Simulator's ObjectAttributesManager instance for configuring object templates.)")
+          .def(
+              "get_physics_template_manager",
+              &Simulator::getPhysicsAttributesManager,
+              pybind11::return_value_policy::reference,
+              R"(Get the Simulator's PhysicsAttributesManager instance for configuring PhysicsManager templates.)")
+          .def(
+              "get_stage_template_manager",
+              &Simulator::getStageAttributesManager,
+              pybind11::return_value_policy::reference,
+              R"(Get the Simulator's StageAttributesManager instance for configuring simulation stage templates.)")
+          .def(
+              "get_physics_simulation_library",
+              &Simulator::getPhysicsSimulationLibrary,
+              R"(Query the physics library implementation currently configured by this Simulator instance.)")
+          /* --- Object instancing and access --- */
+          .def(
+              "add_object", &Simulator::addObject, "object_lib_id"_a,
+              "attachment_node"_a = nullptr,
+              "light_setup_key"_a =
+                  assets::ResourceManager::DEFAULT_LIGHTING_KEY,
+              "scene_id"_a = 0,
+              R"(Instance an object into the scene via a template referenced by library id. Optionally attach the object to an existing SceneNode and assign its initial LightSetup key.)")
+          .def(
+              "add_object_by_handle", &Simulator::addObjectByHandle,
+              "object_lib_handle"_a, "attachment_node"_a = nullptr,
+              "light_setup_key"_a =
+                  assets::ResourceManager::DEFAULT_LIGHTING_KEY,
+              "scene_id"_a = 0,
+              R"(Instance an object into the scene via a template referenced by its handle. Optionally attach the object to an existing SceneNode and assign its initial LightSetup key.)")
+          .def("remove_object", &Simulator::removeObject, "object_id"_a,
+               "delete_object_node"_a = true, "delete_visual_node"_a = true,
+               "scene_id"_a = 0, R"(
         Remove an object instance from the scene. Optionally leave its root SceneNode and visual SceneNode on the SceneGraph.
 
         .. note-warning::
@@ -129,193 +136,233 @@ void initSimBindings(py::module& m) {
             of an Agent expected to continue producing observations
             will likely result in errors if delete_object_node is true.
             )")
-      .def(
-          "get_object_initialization_template",
-          &Simulator::getObjectInitializationTemplate, "object_id"_a,
-          "scene_id"_a = 0,
-          R"(Get a copy of the ObjectAttributes template used to instance an object.)")
-      .def("get_object_motion_type", &Simulator::getObjectMotionType,
-           "object_id"_a, "scene_id"_a = 0,
-           R"(Get the MotionType of an object.)")
-      .def("set_object_motion_type", &Simulator::setObjectMotionType,
-           "motion_type"_a, "object_id"_a, "scene_id"_a = 0,
-           R"(Set the MotionType of an object.)")
-      .def(
-          "get_existing_object_ids", &Simulator::getExistingObjectIDs,
-          "scene_id"_a = 0,
-          R"(Get the list of ids for all objects currently instanced in the scene.)")
+          .def(
+              "get_object_initialization_template",
+              &Simulator::getObjectInitializationTemplate, "object_id"_a,
+              "scene_id"_a = 0,
+              R"(Get a copy of the ObjectAttributes template used to instance an object.)")
+          .def("get_object_motion_type", &Simulator::getObjectMotionType,
+               "object_id"_a, "scene_id"_a = 0,
+               R"(Get the MotionType of an object.)")
+          .def("set_object_motion_type", &Simulator::setObjectMotionType,
+               "motion_type"_a, "object_id"_a, "scene_id"_a = 0,
+               R"(Set the MotionType of an object.)")
+          .def(
+              "get_existing_object_ids", &Simulator::getExistingObjectIDs,
+              "scene_id"_a = 0,
+              R"(Get the list of ids for all objects currently instanced in the scene.)")
 
-      /* --- Kinematics and dynamics --- */
-      .def(
-          "step_world", &Simulator::stepWorld, "dt"_a = 1.0 / 60.0,
-          R"(Step the physics simulation by a desired timestep (dt). Note that resulting world time after step may not be exactly t+dt. Use get_world_time to query current simulation time.)")
-      .def("get_world_time", &Simulator::getWorldTime,
-           R"(Query the current simualtion world time.)")
-      .def("get_gravity", &Simulator::getGravity, "scene_id"_a = 0,
-           R"(Query the gravity vector for a scene.)")
-      .def("set_gravity", &Simulator::setGravity, "gravity"_a, "scene_id"_a = 0,
-           R"(Set the gravity vector for a scene.)")
-      .def(
-          "get_object_scene_node", &Simulator::getObjectSceneNode,
-          "object_id"_a, "scene_id"_a = 0,
-          R"(Get a reference to the root SceneNode of an object's SceneGraph subtree.)")
-      .def(
-          "get_object_visual_scene_nodes",
-          &Simulator::getObjectVisualSceneNodes, "object_id"_a,
-          "scene_id"_a = 0,
-          R"(Get a list of references to the SceneNodes with an object's render assets attached. Use this to manipulate the visual state of an object. Changes to these nodes will not affect physics simulation.)")
-      .def(
-          "set_transformation", &Simulator::setTransformation, "transform"_a,
-          "object_id"_a, "scene_id"_a = 0,
-          R"(Set the transformation matrix of an object's root SceneNode and update its simulation state.)")
-      .def("get_transformation", &Simulator::getTransformation, "object_id"_a,
-           "scene_id"_a = 0,
-           R"(Get the transformation matrix of an object's root SceneNode.)")
-      .def(
-          "set_rigid_state", &Simulator::setRigidState, "rigid_state"_a,
-          "object_id"_a, "scene_id"_a = 0,
-          R"(Set the transformation of an object from a RigidState and update its simulation state.)")
-      .def(
-          "get_rigid_state", &Simulator::getRigidState, "object_id"_a,
-          "scene_id"_a = 0,
-          R"(Get an object's transformation as a RigidState (i.e. vector, quaternion).)")
-      .def("set_translation", &Simulator::setTranslation, "translation"_a,
-           "object_id"_a, "scene_id"_a = 0,
-           R"(Set an object's translation and update its simulation state.)")
-      .def("get_translation", &Simulator::getTranslation, "object_id"_a,
-           "scene_id"_a = 0, R"(Get an object's translation.)")
-      .def("set_rotation", &Simulator::setRotation, "rotation"_a, "object_id"_a,
-           "scene_id"_a = 0,
-           R"(Set an object's orientation and update its simulation state.)")
-      .def("get_rotation", &Simulator::getRotation, "object_id"_a,
-           "scene_id"_a = 0, R"(Get an object's orientation.)")
-      .def(
-          "get_object_velocity_control", &Simulator::getObjectVelocityControl,
-          "object_id"_a, "scene_id"_a = 0,
-          R"(Get a reference to an object's VelocityControl struct. Use this to set constant control velocities for MotionType::KINEMATIC and MotionType::DYNAMIC objects.)")
-      .def(
-          "set_linear_velocity", &Simulator::setLinearVelocity, "linVel"_a,
-          "object_id"_a, "scene_id"_a = 0,
-          R"(Set the linear component of an object's velocity. Only applies to MotionType::DYNAMIC objects.)")
-      .def(
-          "get_linear_velocity", &Simulator::getLinearVelocity, "object_id"_a,
-          "scene_id"_a = 0,
-          R"(Get the linear component of an object's velocity. Only non-zero for MotionType::DYNAMIC objects.)")
-      .def(
-          "set_angular_velocity", &Simulator::setAngularVelocity, "angVel"_a,
-          "object_id"_a, "scene_id"_a = 0,
-          R"(Set the angular component of an object's velocity. Only applies to MotionType::DYNAMIC objects.)")
-      .def(
-          "get_angular_velocity", &Simulator::getAngularVelocity, "object_id"_a,
-          "scene_id"_a = 0,
-          R"(Get the angular component of an object's velocity. Only non-zero for MotionType::DYNAMIC objects.)")
-      .def(
-          "apply_force", &Simulator::applyForce, "force"_a,
-          "relative_position"_a, "object_id"_a, "scene_id"_a = 0,
-          R"(Apply an external force to an object at a specific point relative to the object's center of mass in global coordinates. Only applies to MotionType::DYNAMIC objects.)")
-      .def(
-          "apply_torque", &Simulator::applyTorque, "torque"_a, "object_id"_a,
-          "scene_id"_a = 0,
-          R"(Apply torque to an object. Only applies to MotionType::DYNAMIC objects.)")
-      .def(
-          "contact_test", &Simulator::contactTest, "object_id"_a,
-          "scene_id"_a = 0,
-          R"(Run collision detection and return a binary indicator of penetration between the specified object and any other collision object. Physics must be enabled.)")
-      .def(
-          "cast_ray", &Simulator::castRay, "ray"_a, "max_distance"_a = 100.0,
-          "scene_id"_a = 0,
-          R"(Cast a ray into the collidable scene and return hit results. Physics must be enabled. max_distance in units of ray length.)")
-      .def("set_object_bb_draw", &Simulator::setObjectBBDraw, "draw_bb"_a,
-           "object_id"_a, "scene_id"_a = 0,
-           R"(Enable or disable bounding box visualization for an object.)")
-      .def(
-          "set_object_semantic_id", &Simulator::setObjectSemanticId,
-          "semantic_id"_a, "object_id"_a, "scene_id"_a = 0,
-          R"(Convenience function to set the semanticId for all visual SceneNodes belonging to an object.)")
-      .def(
-          "recompute_navmesh", &Simulator::recomputeNavMesh, "pathfinder"_a,
-          "navmesh_settings"_a, "include_static_objects"_a = false,
-          R"(Recompute the NavMesh for a given PathFinder instance using configured NavMeshSettings. Optionally include all MotionType::STATIC objects in the navigability constraints.)")
-      .def("get_light_setup", &Simulator::getLightSetup,
-           "key"_a = assets::ResourceManager::DEFAULT_LIGHTING_KEY,
-           R"(Get a copy of the LightSetup registered with a specific key.)")
-      .def(
-          "set_light_setup", &Simulator::setLightSetup, "light_setup"_a,
-          "key"_a = assets::ResourceManager::DEFAULT_LIGHTING_KEY,
-          R"(Register a LightSetup with a specific key. If a LightSetup is already registered with this key, it will be overriden. All Drawables referencing the key will use the newly registered LightSetup.)")
-      .def(
-          "set_object_light_setup", &Simulator::setObjectLightSetup,
-          "object_id"_a, "light_setup_key"_a, "scene_id"_a = 0,
-          R"(Modify the LightSetup used to the render all components of an object by setting the LightSetup key referenced by all Drawables attached to the object's visual SceneNodes.)")
+          /* --- Kinematics and dynamics --- */
+          .def(
+              "step_world", &Simulator::stepWorld, "dt"_a = 1.0 / 60.0,
+              R"(Step the physics simulation by a desired timestep (dt). Note that resulting world time after step may not be exactly t+dt. Use get_world_time to query current simulation time.)")
+          .def("get_world_time", &Simulator::getWorldTime,
+               R"(Query the current simualtion world time.)")
+          .def("get_gravity", &Simulator::getGravity, "scene_id"_a = 0,
+               R"(Query the gravity vector for a scene.)")
+          .def("set_gravity", &Simulator::setGravity, "gravity"_a,
+               "scene_id"_a = 0, R"(Set the gravity vector for a scene.)")
+          .def(
+              "get_object_scene_node", &Simulator::getObjectSceneNode,
+              "object_id"_a, "scene_id"_a = 0,
+              R"(Get a reference to the root SceneNode of an object's SceneGraph subtree.)")
+          .def(
+              "get_object_visual_scene_nodes",
+              &Simulator::getObjectVisualSceneNodes, "object_id"_a,
+              "scene_id"_a = 0,
+              R"(Get a list of references to the SceneNodes with an object's render assets attached. Use this to manipulate the visual state of an object. Changes to these nodes will not affect physics simulation.)")
+          .def(
+              "set_transformation", &Simulator::setTransformation,
+              "transform"_a, "object_id"_a, "scene_id"_a = 0,
+              R"(Set the transformation matrix of an object's root SceneNode and update its simulation state.)")
+          .def(
+              "get_transformation", &Simulator::getTransformation,
+              "object_id"_a, "scene_id"_a = 0,
+              R"(Get the transformation matrix of an object's root SceneNode.)")
+          .def(
+              "set_rigid_state", &Simulator::setRigidState, "rigid_state"_a,
+              "object_id"_a, "scene_id"_a = 0,
+              R"(Set the transformation of an object from a RigidState and update its simulation state.)")
+          .def(
+              "get_rigid_state", &Simulator::getRigidState, "object_id"_a,
+              "scene_id"_a = 0,
+              R"(Get an object's transformation as a RigidState (i.e. vector, quaternion).)")
+          .def(
+              "set_translation", &Simulator::setTranslation, "translation"_a,
+              "object_id"_a, "scene_id"_a = 0,
+              R"(Set an object's translation and update its simulation state.)")
+          .def("get_translation", &Simulator::getTranslation, "object_id"_a,
+               "scene_id"_a = 0, R"(Get an object's translation.)")
+          .def(
+              "set_rotation", &Simulator::setRotation, "rotation"_a,
+              "object_id"_a, "scene_id"_a = 0,
+              R"(Set an object's orientation and update its simulation state.)")
+          .def("get_rotation", &Simulator::getRotation, "object_id"_a,
+               "scene_id"_a = 0, R"(Get an object's orientation.)")
+          .def(
+              "get_object_velocity_control",
+              &Simulator::getObjectVelocityControl, "object_id"_a,
+              "scene_id"_a = 0,
+              R"(Get a reference to an object's VelocityControl struct. Use this to set constant control velocities for MotionType::KINEMATIC and MotionType::DYNAMIC objects.)")
+          .def(
+              "set_linear_velocity", &Simulator::setLinearVelocity, "linVel"_a,
+              "object_id"_a, "scene_id"_a = 0,
+              R"(Set the linear component of an object's velocity. Only applies to MotionType::DYNAMIC objects.)")
+          .def(
+              "get_linear_velocity", &Simulator::getLinearVelocity,
+              "object_id"_a, "scene_id"_a = 0,
+              R"(Get the linear component of an object's velocity. Only non-zero for MotionType::DYNAMIC objects.)")
+          .def(
+              "set_angular_velocity", &Simulator::setAngularVelocity,
+              "angVel"_a, "object_id"_a, "scene_id"_a = 0,
+              R"(Set the angular component of an object's velocity. Only applies to MotionType::DYNAMIC objects.)")
+          .def(
+              "get_angular_velocity", &Simulator::getAngularVelocity,
+              "object_id"_a, "scene_id"_a = 0,
+              R"(Get the angular component of an object's velocity. Only non-zero for MotionType::DYNAMIC objects.)")
+          .def(
+              "apply_force", &Simulator::applyForce, "force"_a,
+              "relative_position"_a, "object_id"_a, "scene_id"_a = 0,
+              R"(Apply an external force to an object at a specific point relative to the object's center of mass in global coordinates. Only applies to MotionType::DYNAMIC objects.)")
+          .def(
+              "apply_torque", &Simulator::applyTorque, "torque"_a,
+              "object_id"_a, "scene_id"_a = 0,
+              R"(Apply torque to an object. Only applies to MotionType::DYNAMIC objects.)")
+          .def(
+              "contact_test", &Simulator::contactTest, "object_id"_a,
+              "scene_id"_a = 0,
+              R"(Run collision detection and return a binary indicator of penetration between the specified object and any other collision object. Physics must be enabled.)")
+          .def(
+              "cast_ray", &Simulator::castRay, "ray"_a,
+              "max_distance"_a = 100.0, "scene_id"_a = 0,
+              R"(Cast a ray into the collidable scene and return hit results. Physics must be enabled. max_distance in units of ray length.)")
+          .def("set_object_bb_draw", &Simulator::setObjectBBDraw, "draw_bb"_a,
+               "object_id"_a, "scene_id"_a = 0,
+               R"(Enable or disable bounding box visualization for an object.)")
+          .def(
+              "set_object_semantic_id", &Simulator::setObjectSemanticId,
+              "semantic_id"_a, "object_id"_a, "scene_id"_a = 0,
+              R"(Convenience function to set the semanticId for all visual SceneNodes belonging to an object.)")
+          .def(
+              "recompute_navmesh", &Simulator::recomputeNavMesh, "pathfinder"_a,
+              "navmesh_settings"_a, "include_static_objects"_a = false,
+              R"(Recompute the NavMesh for a given PathFinder instance using configured NavMeshSettings. Optionally include all MotionType::STATIC objects in the navigability constraints.)")
+          .def(
+              "get_light_setup", &Simulator::getLightSetup,
+              "key"_a = assets::ResourceManager::DEFAULT_LIGHTING_KEY,
+              R"(Get a copy of the LightSetup registered with a specific key.)")
+          .def(
+              "set_light_setup", &Simulator::setLightSetup, "light_setup"_a,
+              "key"_a = assets::ResourceManager::DEFAULT_LIGHTING_KEY,
+              R"(Register a LightSetup with a specific key. If a LightSetup is already registered with this key, it will be overriden. All Drawables referencing the key will use the newly registered LightSetup.)")
+          .def(
+              "set_object_light_setup", &Simulator::setObjectLightSetup,
+              "object_id"_a, "light_setup_key"_a, "scene_id"_a = 0,
+              R"(Modify the LightSetup used to the render all components of an object by setting the LightSetup key referenced by all Drawables attached to the object's visual SceneNodes.)")
 
-      /* --- URDF and ArticualtedObject API functions --- */
-      .def("add_articulated_object_from_urdf",
-           &Simulator::addArticulatedObjectFromURDF, "object_id"_a,
-           "fixed_base"_a = false)
-      .def("remove_articulated_object", &Simulator::removeArticulatedObject,
-           "object_id"_a)
-      .def("get_existing_articulated_object_ids",
-           &Simulator::getExistingArticulatedObjectIDs, "scene_id"_a = 0)
-      .def("set_articulated_object_root_state",
-           &Simulator::setArticulatedObjectRootState, "object_id"_a, "state"_a)
-      .def("get_articulated_object_root_state",
-           &Simulator::getArticulatedObjectRootState, "object_id"_a)
-      .def("set_articulated_object_forces",
-           &Simulator::setArticulatedObjectForces, "object_id"_a, "forces"_a)
-      .def("set_articulated_object_velocities",
-           &Simulator::setArticulatedObjectVelocities, "object_id"_a, "vels"_a)
-      .def("set_articulated_object_positions",
-           &Simulator::setArticulatedObjectPositions, "object_id"_a,
-           "positions"_a)
-      .def("get_articulated_object_positions",
-           &Simulator::getArticulatedObjectPositions, "object_id"_a)
-      .def("get_articulated_object_velocities",
-           &Simulator::getArticulatedObjectVelocities, "object_id"_a)
-      .def("get_articulated_object_forces",
-           &Simulator::getArticulatedObjectForces, "object_id"_a)
-      .def("reset_articulated_object", &Simulator::resetArticulatedObject,
-           "object_id"_a)
-      .def("set_articulated_object_sleep",
-           &Simulator::setArticulatedObjectSleep, "object_id"_a,
-           "sleep"_a = true)
-      .def("get_articulated_object_sleep",
-           &Simulator::getArticulatedObjectSleep, "object_id"_a)
-      .def("set_articulated_object_motion_type",
-           &Simulator::setArticulatedObjectMotionType, "object_id"_a,
-           "motion_type"_a)
-      .def("get_articulated_object_motion_type",
-           &Simulator::getArticulatedObjectMotionType, "object_id"_a)
-      .def("get_num_articulated_links", &Simulator::getNumArticulatedLinks,
-           "object_id"_a)
-      .def("get_articulated_link_rigid_state",
-           &Simulator::getArticulatedLinkRigidState, "object_id"_a, "link_id"_a)
+          /* --- URDF and ArticualtedObject API functions --- */
+          .def("add_articulated_object_from_urdf",
+               &Simulator::addArticulatedObjectFromURDF, "object_id"_a,
+               "fixed_base"_a = false)
+          .def("remove_articulated_object", &Simulator::removeArticulatedObject,
+               "object_id"_a)
+          .def("get_existing_articulated_object_ids",
+               &Simulator::getExistingArticulatedObjectIDs, "scene_id"_a = 0)
+          .def("set_articulated_object_root_state",
+               &Simulator::setArticulatedObjectRootState, "object_id"_a,
+               "state"_a)
+          .def("get_articulated_object_root_state",
+               &Simulator::getArticulatedObjectRootState, "object_id"_a)
+          .def("set_articulated_object_forces",
+               &Simulator::setArticulatedObjectForces, "object_id"_a,
+               "forces"_a)
+          .def("set_articulated_object_velocities",
+               &Simulator::setArticulatedObjectVelocities, "object_id"_a,
+               "vels"_a)
+          .def("set_articulated_object_positions",
+               &Simulator::setArticulatedObjectPositions, "object_id"_a,
+               "positions"_a)
+          .def("get_articulated_object_positions",
+               &Simulator::getArticulatedObjectPositions, "object_id"_a)
+          .def("get_articulated_object_velocities",
+               &Simulator::getArticulatedObjectVelocities, "object_id"_a)
+          .def("get_articulated_object_forces",
+               &Simulator::getArticulatedObjectForces, "object_id"_a)
+          .def("reset_articulated_object", &Simulator::resetArticulatedObject,
+               "object_id"_a)
+          .def("set_articulated_object_sleep",
+               &Simulator::setArticulatedObjectSleep, "object_id"_a,
+               "sleep"_a = true)
+          .def("get_articulated_object_sleep",
+               &Simulator::getArticulatedObjectSleep, "object_id"_a)
+          .def("set_articulated_object_motion_type",
+               &Simulator::setArticulatedObjectMotionType, "object_id"_a,
+               "motion_type"_a)
+          .def("get_articulated_object_motion_type",
+               &Simulator::getArticulatedObjectMotionType, "object_id"_a)
+          .def("get_num_articulated_links", &Simulator::getNumArticulatedLinks,
+               "object_id"_a)
+          .def("get_articulated_link_rigid_state",
+               &Simulator::getArticulatedLinkRigidState, "object_id"_a,
+               "link_id"_a)
 
-      /* --- Joint Motor API --- */
-      .def("create_joint_motor", &Simulator::createJointMotor, "object_id"_a,
-           "dof"_a, "settings"_a)
-      .def("remove_joint_motor", &Simulator::removeJointMotor, "object_id"_a,
-           "motor_id"_a)
-      .def("get_joint_motor_settings", &Simulator::getJointMotorSettings,
-           "object_id"_a, "motor_id"_a)
-      .def("update_joint_motor", &Simulator::updateJointMotor, "object_id"_a,
-           "motor_id"_a, "settings"_a)
-      .def("get_existing_joint_motors", &Simulator::getExistingJointMotors,
-           "object_id"_a)
-      .def("create_motors_for_all_dofs", &Simulator::createMotorsForAllDofs,
-           "object_id"_a, "settings"_a = esp::physics::JointMotorSettings())
+          /* --- Joint Motor API --- */
+          .def("create_joint_motor", &Simulator::createJointMotor,
+               "object_id"_a, "dof"_a, "settings"_a)
+          .def("remove_joint_motor", &Simulator::removeJointMotor,
+               "object_id"_a, "motor_id"_a)
+          .def("get_joint_motor_settings", &Simulator::getJointMotorSettings,
+               "object_id"_a, "motor_id"_a)
+          .def("update_joint_motor", &Simulator::updateJointMotor,
+               "object_id"_a, "motor_id"_a, "settings"_a)
+          .def("get_existing_joint_motors", &Simulator::getExistingJointMotors,
+               "object_id"_a)
+          .def("create_motors_for_all_dofs", &Simulator::createMotorsForAllDofs,
+               "object_id"_a, "settings"_a = esp::physics::JointMotorSettings())
 
-      .def(
-          "get_physics_num_active_contact_points",
-          &Simulator::getPhysicsNumActiveContactPoints,
-          R"(The number of contact points that were active during the last step. An object resting on another object will involve several active contact points. Once both objects are asleep, the contact points are inactive. This count is a proxy for complexity/cost of collision-handling in the current scene.)")
-      .def(
-          "get_physics_num_active_overlapping_pairs",
-          &Simulator::getPhysicsNumActiveOverlappingPairs,
-          R"(The number of active overlapping pairs during the last step. When object bounding boxes overlap and either object is active, additional "narrowphase" collision-detection must be run. This count is a proxy for complexity/cost of collision-handling in the current scene.)")
-      .def(
-          "get_physics_step_collision_summary",
-          &Simulator::getPhysicsStepCollisionSummary,
-          R"(Get a summary of collision-processing from the last physics step.)");
+          .def("override_collision_group", &Simulator::overrideCollisionGroup,
+               "object_id"_a, "group"_a,
+               R"(see Habitat-Sim CollisionGroupHelper.h)")
+
+          .def(
+              "create_articulated_p2p_constraint",
+              &Simulator::createArticulatedP2PConstraint, "object_id_a"_a,
+              "link_id"_a, "object_id_b"_a, "max_impulse"_a = 1.0,
+              R"(add p2p constraint between articulated object a link and an object; the pivot is at the object's origin)")
+
+          .def(
+              "create_articulated_p2p_constraint_with_pivots",
+              &Simulator::createArticulatedP2PConstraintWithPivots,
+              "object_id_a"_a, "link_id"_a, "object_id_b"_a, "pivot_a"_a,
+              "pivot_b"_a, "max_impulse"_a = 1.0,
+              R"(add p2p constraint between articulated object a link and an object; pivots are specified in the link/object's local space)")
+
+          .def(
+              "create_articulated_fixed_constraint",
+              &Simulator::createArticulatedFixedConstraint, "object_id_a"_a,
+              "link_id"_a, "object_id_b"_a, "max_impulse"_a = 1.0,
+              R"(add fixed constraint between articulated object a link and an object; the pivot is at the object's origin; the current relative orientation of the link and the object will be fixed)")
+
+          .def(
+              "create_articulated_fixed_constraint_with_pivots",
+              &Simulator::createArticulatedFixedConstraintWithPivots,
+              "object_id_a"_a, "link_id"_a, "object_id_b"_a, "pivot_a"_a,
+              "pivot_b"_a, "max_impulse"_a = 1.0,
+              R"(add fixed constraint between articulated object link and rigid object; pivots are specified in the link/object's local space; the current relative orientation of the link and the object will be fixed)")
+
+          .def("remove_constraint", &Simulator::removeConstraint,
+               "constraint_id"_a, R"(See create_articulated_p2p_constraint)")
+
+          .def(
+              "get_physics_num_active_contact_points", &Simulator::getPhysicsNumActiveContactPoints, R"(The number of contact points that were active during the last step. An object resting on another object will involve several active contact points. Once both objects are asleep, the contact points are inactive. This count is a proxy for complexity/cost of collision-handling in the current scene.)")
+          .def(
+              "get_physics_num_active_overlapping_pairs",
+              &Simulator::getPhysicsNumActiveOverlappingPairs,
+              R"(The number of active overlapping pairs during the last step. When object bounding boxes overlap and either object is active, additional "narrowphase" collision-detection must be run. This count is a proxy for complexity/cost of collision-handling in the current scene.)")
+          .def(
+              "get_physics_step_collision_summary",
+              &Simulator::getPhysicsStepCollisionSummary,
+              R"(Get a summary of collision-processing from the last physics step.)");
 }
 
 }  // namespace sim

--- a/src/esp/physics/CMakeLists.txt
+++ b/src/esp/physics/CMakeLists.txt
@@ -11,6 +11,8 @@ configure_file(
 add_library(
   physics STATIC
   ArticulatedObject.h
+  CollisionGroupHelper.cpp
+  CollisionGroupHelper.h
   PhysicsManager.cpp
   PhysicsManager.h
   RigidBase.h

--- a/src/esp/physics/CollisionGroupHelper.cpp
+++ b/src/esp/physics/CollisionGroupHelper.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "CollisionGroupHelper.h"
+
+#include "esp/core/logging.h"
+
+namespace esp {
+namespace physics {
+
+/*
+  enum class CollisionGroup {
+    Default = 1,
+    Static = 2,
+    Kinematic = 4,
+    FreeObject = 8,
+    GraspedObject = 16,
+    Robot = 32,
+  };
+*/
+
+int CollisionGroupHelper::getMaskForGroup(CollisionGroup group) {
+  // todo: refactor this in terms of enabling collision between specific pairs
+  // of groups
+  switch (group) {
+    case CollisionGroup::Default:
+      // everything
+      return -1;
+
+    case CollisionGroup::Static:
+      // everything but kinematic
+      return int(-1) & ~int(CollisionGroup::Kinematic);
+
+    case CollisionGroup::Kinematic:
+      // everything but static
+      return int(-1) & ~int(CollisionGroup::Static);
+
+    case CollisionGroup::FreeObject:
+      // everything
+      return int(-1);
+
+    case CollisionGroup::GraspedObject:
+      // everything but robot
+      return int(-1) & ~int(CollisionGroup::Robot);
+
+    case CollisionGroup::Robot:
+      // everything but grasped object
+      return int(-1) & ~int(CollisionGroup::GraspedObject);
+
+    default:
+      ASSERT(false);
+      return 0;
+  }
+}
+
+}  // namespace physics
+}  // namespace esp

--- a/src/esp/physics/CollisionGroupHelper.h
+++ b/src/esp/physics/CollisionGroupHelper.h
@@ -1,0 +1,42 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+namespace esp {
+namespace physics {
+
+/*
+  For reference, here are the standard Bullet groups. It's probably good to
+  stay somewhat consistent with them, in case users are already using them.
+
+        enum CollisionFilterGroups
+        {
+                DefaultFilter = 1,
+                StaticFilter = 2,
+                KinematicFilter = 4,
+                DebrisFilter = 8,
+                SensorTrigger = 16,
+                CharacterFilter = 32,
+                AllFilter = -1  //all bits sets: DefaultFilter | StaticFilter |
+  KinematicFilter | DebrisFilter | SensorTrigger
+        };
+*/
+
+enum class CollisionGroup {
+  Default = 1,
+  Static = 2,
+  Kinematic = 4,
+  FreeObject = 8,
+  GraspedObject = 16,
+  Robot = 32,
+};
+
+class CollisionGroupHelper {
+ public:
+  static int getMaskForGroup(CollisionGroup group);
+};
+
+}  // end namespace physics
+}  // end namespace esp

--- a/src/esp/physics/PhysicsManager.h
+++ b/src/esp/physics/PhysicsManager.h
@@ -18,6 +18,7 @@
 /* Bullet Physics Integration */
 
 #include "ArticulatedObject.h"
+#include "CollisionGroupHelper.h"
 #include "RigidObject.h"
 #include "RigidStage.h"
 #include "esp/assets/Asset.h"
@@ -373,6 +374,30 @@ class PhysicsManager {
     return existingArticulatedObjects_.at(objectId)->createMotorsForAllDofs(
         settings);
   };
+
+  //============ Constraint functions =============
+
+  virtual int createArticulatedP2PConstraint(
+      int articulatedObjectId,
+      int linkId,
+      int objectId,
+      float maxImpulse,
+      const Corrade::Containers::Optional<Magnum::Vector3>& pivotA,
+      const Corrade::Containers::Optional<Magnum::Vector3>& pivotB) {
+    return -1;
+  }
+
+  virtual int createArticulatedFixedConstraint(
+      int articulatedObjectId,
+      int linkId,
+      int objectId,
+      float maxImpulse,
+      const Corrade::Containers::Optional<Magnum::Vector3>& pivotA,
+      const Corrade::Containers::Optional<Magnum::Vector3>& pivotB) {
+    return -1;
+  }
+
+  virtual void removeConstraint(int constraintId) {}
 
   //============ Simulator functions =============
 
@@ -965,6 +990,9 @@ class PhysicsManager {
   virtual bool contactTest(CORRADE_UNUSED const int physObjectID) {
     return false;
   };
+
+  virtual void overrideCollisionGroup(const int physObjectID,
+                                      CollisionGroup group) const {}
 
   /** @brief Return the library implementation type for the simulator currently
    * in use. Use to check for a particular implementation.

--- a/src/esp/physics/bullet/BulletPhysicsManager.cpp
+++ b/src/esp/physics/bullet/BulletPhysicsManager.cpp
@@ -279,6 +279,13 @@ bool BulletPhysicsManager::contactTest(const int physObjectID) {
       ->contactTest();
 }
 
+void BulletPhysicsManager::overrideCollisionGroup(const int physObjectID,
+                                                  CollisionGroup group) const {
+  assertIDValidity(physObjectID);
+  static_cast<BulletRigidObject*>(existingObjects_.at(physObjectID).get())
+      ->overrideCollisionGroup(group);
+}
+
 int BulletPhysicsManager::createRigidP2PConstraint(
     int objectId,
     Magnum::Vector3 localOffset) {
@@ -291,8 +298,8 @@ int BulletPhysicsManager::createRigidP2PConstraint(
     btPoint2PointConstraint* p2p =
         new btPoint2PointConstraint(*rb, btVector3(localOffset));
     bWorld_->addConstraint(p2p);
-    rigidP2ps.emplace(nextP2PId_, p2p);
-    return nextP2PId_++;
+    rigidP2ps.emplace(nextConstraintId_, p2p);
+    return nextConstraintId_++;
   } else {
     Corrade::Utility::Debug()
         << "Cannot create a dynamic point-2-point constraint for object with "
@@ -335,8 +342,8 @@ int BulletPhysicsManager::createArticulatedP2PConstraint(
   btScalar scaling = 1;
   p2p->setMaxAppliedImpulse(2 * scaling);
   bWorld_->addMultiBodyConstraint(p2p);
-  articulatedP2ps.emplace(nextP2PId_, p2p);
-  return nextP2PId_++;
+  articulatedP2ps.emplace(nextConstraintId_, p2p);
+  return nextConstraintId_++;
 }
 
 int BulletPhysicsManager::createArticulatedP2PConstraint(
@@ -355,32 +362,147 @@ int BulletPhysicsManager::createArticulatedP2PConstraint(
                                         Magnum::Vector3(pivotInA), pickPos);
 }
 
-void BulletPhysicsManager::updateP2PConstraintPivot(int p2pId,
+void BulletPhysicsManager::updateP2PConstraintPivot(int constraintId,
                                                     Magnum::Vector3 pivot) {
-  if (articulatedP2ps.count(p2pId)) {
-    articulatedP2ps.at(p2pId)->setPivotInB(btVector3(pivot));
-  } else if (rigidP2ps.count(p2pId)) {
-    rigidP2ps.at(p2pId)->setPivotB(btVector3(pivot));
+  if (articulatedP2ps.count(constraintId)) {
+    articulatedP2ps.at(constraintId)->setPivotInB(btVector3(pivot));
+  } else if (rigidP2ps.count(constraintId)) {
+    rigidP2ps.at(constraintId)->setPivotB(btVector3(pivot));
   } else {
-    Corrade::Utility::Debug() << "No P2P constraint with ID: " << p2pId;
+    Corrade::Utility::Debug() << "No P2P constraint with ID: " << constraintId;
   }
 }
 
-void BulletPhysicsManager::removeP2PConstraint(int p2pId) {
-  if (articulatedP2ps.count(p2pId)) {
-    articulatedP2ps.at(p2pId)->getMultiBodyA()->setCanSleep(true);
-    bWorld_->removeMultiBodyConstraint(articulatedP2ps.at(p2pId));
-    delete articulatedP2ps.at(p2pId);
-    articulatedP2ps.erase(p2pId);
-  } else if (rigidP2ps.count(p2pId)) {
-    rigidP2ps.at(p2pId)->getRigidBodyA().setActivationState(WANTS_DEACTIVATION);
-    bWorld_->removeConstraint(rigidP2ps.at(p2pId));
-    delete rigidP2ps.at(p2pId);
-    rigidP2ps.erase(p2pId);
+void BulletPhysicsManager::removeConstraint(int constraintId) {
+  if (articulatedP2ps.count(constraintId)) {
+    articulatedP2ps.at(constraintId)->getMultiBodyA()->setCanSleep(true);
+    bWorld_->removeMultiBodyConstraint(articulatedP2ps.at(constraintId));
+    delete articulatedP2ps.at(constraintId);
+    articulatedP2ps.erase(constraintId);
+  } else if (rigidP2ps.count(constraintId)) {
+    rigidP2ps.at(constraintId)
+        ->getRigidBodyA()
+        .setActivationState(WANTS_DEACTIVATION);
+    bWorld_->removeConstraint(rigidP2ps.at(constraintId));
+    delete rigidP2ps.at(constraintId);
+    rigidP2ps.erase(constraintId);
+  } else if (articulatedFixedConstraints.count(constraintId)) {
+    bWorld_->removeMultiBodyConstraint(
+        articulatedFixedConstraints.at(constraintId));
+    delete articulatedFixedConstraints.at(constraintId);
+    articulatedFixedConstraints.erase(constraintId);
   } else {
-    Corrade::Utility::Debug() << "No P2P constraint with ID: " << p2pId;
+    Corrade::Utility::Debug() << "No constraint with ID: " << constraintId;
   }
 };
+
+int BulletPhysicsManager::createArticulatedP2PConstraint(
+    int articulatedObjectId,
+    int linkId,
+    int objectId,
+    float maxImpulse,
+    const Corrade::Containers::Optional<Magnum::Vector3>& pivotA,
+    const Corrade::Containers::Optional<Magnum::Vector3>& pivotB) {
+  CHECK(existingArticulatedObjects_.count(articulatedObjectId));
+  CHECK(existingArticulatedObjects_.at(articulatedObjectId)->getNumLinks() >
+        linkId);
+  CHECK(existingObjects_.count(objectId));
+
+  btRigidBody* rb = nullptr;
+  if (existingObjects_.at(objectId)->getMotionType() == MotionType::DYNAMIC) {
+    rb = static_cast<BulletRigidObject*>(existingObjects_.at(objectId).get())
+             ->bObjectRigidBody_.get();
+  } else {
+    Corrade::Utility::Debug()
+        << "Cannot create a dynamic P2P constraint for object with "
+           "MotionType != DYNAMIC";
+    return ID_UNDEFINED;
+  }
+
+  btMultiBody* mb =
+      static_cast<BulletArticulatedObject*>(
+          existingArticulatedObjects_.at(articulatedObjectId).get())
+          ->btMultiBody_;
+  mb->setCanSleep(false);
+
+  // use origin if not specified
+  btVector3 pivotInB = pivotB ? btVector3(*pivotB) : btVector3(0.f, 0.f, 0.f);
+
+  btVector3 pivotInA;
+  if (pivotA) {
+    pivotInA = btVector3(*pivotA);
+  } else {
+    // hold object at it's current position relative to link
+    btVector3 pivotWorld = rb->getCenterOfMassTransform() * pivotInB;
+    pivotInA = mb->worldPosToLocal(linkId, pivotWorld);
+  }
+
+  btMultiBodyPoint2Point* p2p =
+      new btMultiBodyPoint2Point(mb, linkId, rb, pivotInA, pivotInB);
+  p2p->setMaxAppliedImpulse(maxImpulse);
+  bWorld_->addMultiBodyConstraint(p2p);
+  articulatedP2ps.emplace(nextConstraintId_, p2p);
+  return nextConstraintId_++;
+}
+
+int BulletPhysicsManager::createArticulatedFixedConstraint(
+    int articulatedObjectId,
+    int linkId,
+    int objectId,
+    float maxImpulse,
+    const Corrade::Containers::Optional<Magnum::Vector3>& pivotA,
+    const Corrade::Containers::Optional<Magnum::Vector3>& pivotB) {
+  CHECK(existingArticulatedObjects_.count(articulatedObjectId));
+  CHECK(existingArticulatedObjects_.at(articulatedObjectId)->getNumLinks() >
+        linkId);
+  CHECK(existingObjects_.count(objectId));
+
+  btRigidBody* rb = nullptr;
+  if (existingObjects_.at(objectId)->getMotionType() == MotionType::DYNAMIC) {
+    rb = static_cast<BulletRigidObject*>(existingObjects_.at(objectId).get())
+             ->bObjectRigidBody_.get();
+  } else {
+    Corrade::Utility::Debug()
+        << "Cannot create a dynamic fixed constraint for object with "
+           "MotionType != DYNAMIC";
+    return ID_UNDEFINED;
+  }
+
+  btMultiBody* mb =
+      static_cast<BulletArticulatedObject*>(
+          existingArticulatedObjects_.at(articulatedObjectId).get())
+          ->btMultiBody_;
+  mb->setCanSleep(false);
+
+  // use origin if not specified
+  // todo: avoid code duplication here and in createArticulatedP2PConstraint
+  btVector3 pivotInB = pivotB ? btVector3(*pivotB) : btVector3(0.f, 0.f, 0.f);
+  btVector3 pivotInA;
+  if (pivotA) {
+    pivotInA = btVector3(*pivotA);
+  } else {
+    // hold object at it's current position relative to link
+    btVector3 pivotWorld = rb->getCenterOfMassTransform() * pivotInB;
+    btVector3 pivotInA = mb->worldPosToLocal(linkId, pivotWorld);
+  }
+
+  // We constrain the relative orientation of the link and object to match their
+  // current relative orientation.
+  btMatrix3x3 frameInA = btMatrix3x3::getIdentity();
+  btMatrix3x3 frameWorld = mb->localFrameToWorld(linkId, frameInA);
+  // note btMatrix3x3 tranpose() equivalent to inverse because mat is
+  // orthonormal
+  btMatrix3x3 frameInB =
+      (frameWorld * rb->getCenterOfMassTransform().getBasis().transpose())
+          .transpose();
+
+  auto* constraint = new btMultiBodyFixedConstraint(
+      mb, linkId, rb, pivotInA, pivotInB, frameInA, frameInB);
+  constraint->setMaxAppliedImpulse(maxImpulse);
+  bWorld_->addMultiBodyConstraint(constraint);
+  articulatedFixedConstraints.emplace(nextConstraintId_, constraint);
+  return nextConstraintId_++;
+}
 
 RaycastResults BulletPhysicsManager::castRay(const esp::geo::Ray& ray,
                                              double maxDistance) {

--- a/src/esp/physics/bullet/BulletRigidObject.h
+++ b/src/esp/physics/bullet/BulletRigidObject.h
@@ -20,6 +20,7 @@
 
 #include "esp/core/esp.h"
 
+#include "esp/physics/CollisionGroupHelper.h"
 #include "esp/physics/RigidObject.h"
 #include "esp/physics/bullet/BulletBase.h"
 
@@ -406,6 +407,8 @@ class BulletRigidObject : public BulletBase,
    * object.
    */
   bool isMe(const btCollisionObject* collisionObject);
+
+  void overrideCollisionGroup(CollisionGroup group);
 
   /** @brief Object data: All components of a @ref RigidObjectType::OBJECT are
    * wrapped into one @ref btRigidBody.

--- a/src/esp/physics/bullet/BulletRigidStage.cpp
+++ b/src/esp/physics/bullet/BulletRigidStage.cpp
@@ -13,6 +13,8 @@
 #include "BulletDebugManager.h"
 #include "BulletRigidStage.h"
 
+#include "esp/physics/CollisionGroupHelper.h"
+
 namespace esp {
 namespace physics {
 
@@ -46,8 +48,9 @@ bool BulletRigidStage::initialization_LibSpecific(
     object->setFriction(initializationAttributes_->getFrictionCoefficient());
     object->setRestitution(
         initializationAttributes_->getRestitutionCoefficient());
-    bWorld_->addRigidBody(object.get(), btBroadphaseProxy::StaticFilter,
-                          btBroadphaseProxy::DefaultFilter);
+    bWorld_->addRigidBody(
+        object.get(), int(CollisionGroup::Static),
+        CollisionGroupHelper::getMaskForGroup(CollisionGroup::Static));
     collisionObjToObjIds_->emplace(object.get(), objectId_);
   }
 

--- a/src/esp/physics/bullet/BulletURDFImporter.cpp
+++ b/src/esp/physics/bullet/BulletURDFImporter.cpp
@@ -13,6 +13,7 @@
 #include "BulletDynamics/Featherstone/btMultiBodyJointLimitConstraint.h"
 #include "BulletDynamics/Featherstone/btMultiBodyLinkCollider.h"
 #include "esp/assets/ResourceManager.h"
+#include "esp/physics/CollisionGroupHelper.h"
 #include "esp/physics/bullet/BulletBase.h"
 
 namespace Mn = Magnum;
@@ -26,7 +27,7 @@ static float gUrdfDefaultCollisionMargin = 0.001;
 
 btCollisionShape* BulletURDFImporter::convertURDFToCollisionShape(
     const io::UrdfCollision* collision) {
-  //Cr::Utility::Debug() << "convertURDFToCollisionShape";
+  // Cr::Utility::Debug() << "convertURDFToCollisionShape";
 
   btCollisionShape* shape = 0;
 
@@ -136,7 +137,7 @@ btCompoundShape* BulletURDFImporter::convertLinkCollisionShapes(
 
   compoundShape->setMargin(gUrdfDefaultCollisionMargin);
 
-  //Cr::Utility::Debug() << " num links = "
+  // Cr::Utility::Debug() << " num links = "
   //                     << urdfParser_.getModel().m_links.size();
 
   auto itr = urdfParser_.getModel().m_links.begin();
@@ -162,7 +163,7 @@ btCompoundShape* BulletURDFImporter::convertLinkCollisionShapes(
         */
 
         Magnum::Matrix4 childTrans = col.m_linkLocalFrame;
-        //Corrade::Utility::Debug() << "col.m_linkLocalFrame: "
+        // Corrade::Utility::Debug() << "col.m_linkLocalFrame: "
         //                          << Magnum::Matrix4(col.m_linkLocalFrame);
 
         compoundShape->addChildShape(
@@ -238,7 +239,7 @@ void BulletURDFImporter::InitURDF2BulletCache(URDF2BulletCached& cache,
   cache.m_totalNumJoints1 = 0;
 
   int rootLinkIndex = getRootLinkIndex();
-  //Cr::Utility::Debug() << "InitURDF2BulletCache() - rootLinkIndex = "
+  // Cr::Utility::Debug() << "InitURDF2BulletCache() - rootLinkIndex = "
   //                     << rootLinkIndex;
   if (rootLinkIndex >= 0) {
     ComputeTotalNumberOfJoints(cache, rootLinkIndex);
@@ -300,33 +301,33 @@ Mn::Matrix4 BulletURDFImporter::ConvertURDF2BulletInternal(
     btMultiBodyDynamicsWorld* world1,
     int flags,
     std::map<int, btCollisionShape*>& linkCollisionShapes) {
-  //Corrade::Utility::Debug() << "++++++++++++++++++++++++++++++++++++++";
-  //Corrade::Utility::Debug() << "ConvertURDF2BulletInternal...";
+  // Corrade::Utility::Debug() << "++++++++++++++++++++++++++++++++++++++";
+  // Corrade::Utility::Debug() << "ConvertURDF2BulletInternal...";
 
   Mn::Matrix4 linkTransformInWorldSpace;
 
-  //Corrade::Utility::Debug() << "  urdfLinkIndex = " << urdfLinkIndex;
+  // Corrade::Utility::Debug() << "  urdfLinkIndex = " << urdfLinkIndex;
 
   int mbLinkIndex = cache.getMbIndexFromUrdfIndex(urdfLinkIndex);
-  //Corrade::Utility::Debug() << "  mbLinkIndex = " << mbLinkIndex;
+  // Corrade::Utility::Debug() << "  mbLinkIndex = " << mbLinkIndex;
 
   int urdfParentIndex = cache.getParentUrdfIndex(urdfLinkIndex);
-  //Corrade::Utility::Debug() << "  urdfParentIndex = " << urdfParentIndex;
+  // Corrade::Utility::Debug() << "  urdfParentIndex = " << urdfParentIndex;
   int mbParentIndex = cache.getMbIndexFromUrdfIndex(urdfParentIndex);
-  //Corrade::Utility::Debug() << "  mbParentIndex = " << mbParentIndex;
+  // Corrade::Utility::Debug() << "  mbParentIndex = " << mbParentIndex;
 
   Mn::Matrix4 parentLocalInertialFrame;
   btScalar parentMass(1);
   Mn::Vector3 parentLocalInertiaDiagonal(1);
 
   if (urdfParentIndex == -2) {
-    //Corrade::Utility::Debug() << "root link has no parent";
+    // Corrade::Utility::Debug() << "root link has no parent";
   } else {
     getMassAndInertia2(urdfParentIndex, parentMass, parentLocalInertiaDiagonal,
                        parentLocalInertialFrame, flags);
   }
 
-  //Corrade::Utility::Debug() << "  about to get mass/inertia";
+  // Corrade::Utility::Debug() << "  about to get mass/inertia";
 
   btScalar mass = 0;
   Mn::Matrix4 localInertialFrame;
@@ -334,7 +335,7 @@ Mn::Matrix4 BulletURDFImporter::ConvertURDF2BulletInternal(
   getMassAndInertia2(urdfLinkIndex, mass, localInertiaDiagonal,
                      localInertialFrame, flags);
 
-  //Corrade::Utility::Debug() << "  about to get joint info";
+  // Corrade::Utility::Debug() << "  about to get joint info";
 
   Mn::Matrix4 parent2joint;
   int jointType;
@@ -358,7 +359,7 @@ Mn::Matrix4 BulletURDFImporter::ConvertURDF2BulletInternal(
     linkTransformInWorldSpace = parentTransformInWorldSpace * parent2joint;
   }
 
-  //Corrade::Utility::Debug() << "  about to convert link collision shapes";
+  // Corrade::Utility::Debug() << "  about to convert link collision shapes";
 
   btCompoundShape* tmpShape = convertLinkCollisionShapes(
       urdfLinkIndex, btTransform(localInertialFrame));
@@ -368,7 +369,7 @@ Mn::Matrix4 BulletURDFImporter::ConvertURDF2BulletInternal(
     compoundShape = tmpShape->getChildShape(0);
   }
 
-  //Corrade::Utility::Debug() << "  about to deal with compoundShape";
+  // Corrade::Utility::Debug() << "  about to deal with compoundShape";
   if (compoundShape) {
     if (mass) {
       if (!(flags & CUF_USE_URDF_INERTIA)) {
@@ -562,7 +563,7 @@ Mn::Matrix4 BulletURDFImporter::ConvertURDF2BulletInternal(
       // simulator will do this when syncing the btMultiBody link transforms to
       // the btMultiBodyLinkCollider
 
-      //Corrade::Utility::Debug()
+      // Corrade::Utility::Debug()
       //    << "~~~~~~~~~~~~~ col->setWorldTransform(btTransform(tr)): " << tr;
 
       col->setWorldTransform(btTransform(tr));
@@ -624,12 +625,10 @@ Mn::Matrix4 BulletURDFImporter::ConvertURDF2BulletInternal(
         cache.m_bulletMultiBody->setBaseCollider(col);
       }
 
-      int collisionFilterGroup = isDynamic
-                                     ? int(btBroadphaseProxy::DefaultFilter)
-                                     : int(btBroadphaseProxy::StaticFilter);
-      int collisionFilterMask = isDynamic
-                                    ? int(btBroadphaseProxy::AllFilter)
-                                    : int(btBroadphaseProxy::DefaultFilter);
+      int collisionFilterGroup =
+          isDynamic ? int(CollisionGroup::Robot) : int(CollisionGroup::Static);
+      int collisionFilterMask = CollisionGroupHelper::getMaskForGroup(
+          CollisionGroup(collisionFilterGroup));
 
       int colGroup = 0, colMask = 0;
       int collisionFlags =
@@ -658,7 +657,7 @@ Mn::Matrix4 BulletURDFImporter::ConvertURDF2BulletInternal(
     }
   }
 
-  //Corrade::Utility::Debug() << "  about to recurse";
+  // Corrade::Utility::Debug() << "  about to recurse";
 
   std::vector<int> urdfChildIndices;
   getLinkChildIndices(urdfLinkIndex, urdfChildIndices);

--- a/src/esp/sim/Simulator.cpp
+++ b/src/esp/sim/Simulator.cpp
@@ -17,6 +17,7 @@
 #include "esp/gfx/Renderer.h"
 #include "esp/io/io.h"
 #include "esp/nav/PathFinder.h"
+#include "esp/physics/CollisionGroupHelper.h"
 #include "esp/physics/PhysicsManager.h"
 #include "esp/physics/bullet/BulletDebugManager.h"
 #include "esp/scene/ObjectControls.h"
@@ -1022,6 +1023,60 @@ std::map<int, int> Simulator::createMotorsForAllDofs(
     return physicsManager_->createMotorsForAllDofs(objectId, settings);
   }
   return std::map<int, int>();
+}
+
+void Simulator::overrideCollisionGroup(int objectID, int group) {
+  // todo: find a safe way to convert int to enum
+  physicsManager_->overrideCollisionGroup(objectID,
+                                          esp::physics::CollisionGroup(group));
+}
+
+int Simulator::createArticulatedP2PConstraint(int articulatedObjectId,
+                                              int linkId,
+                                              int objectId,
+                                              float maxImpulse) {
+  ASSERT(sceneHasPhysics(0));
+  return physicsManager_->createArticulatedP2PConstraint(
+      articulatedObjectId, linkId, objectId, maxImpulse,
+      Corrade::Containers::NullOpt, Corrade::Containers::NullOpt);
+}
+
+int Simulator::createArticulatedP2PConstraintWithPivots(
+    int articulatedObjectId,
+    int linkId,
+    int objectId,
+    const Magnum::Vector3& pivotA,
+    const Magnum::Vector3& pivotB,
+    float maxImpulse) {
+  ASSERT(sceneHasPhysics(0));
+  return physicsManager_->createArticulatedP2PConstraint(
+      articulatedObjectId, linkId, objectId, maxImpulse, pivotA, pivotB);
+}
+
+int Simulator::createArticulatedFixedConstraint(int articulatedObjectId,
+                                                int linkId,
+                                                int objectId,
+                                                float maxImpulse) {
+  ASSERT(sceneHasPhysics(0));
+  return physicsManager_->createArticulatedFixedConstraint(
+      articulatedObjectId, linkId, objectId, maxImpulse,
+      Corrade::Containers::NullOpt, Corrade::Containers::NullOpt);
+}
+
+int Simulator::createArticulatedFixedConstraintWithPivots(
+    int articulatedObjectId,
+    int linkId,
+    int objectId,
+    const Magnum::Vector3& pivotA,
+    const Magnum::Vector3& pivotB,
+    float maxImpulse) {
+  ASSERT(sceneHasPhysics(0));
+  return physicsManager_->createArticulatedFixedConstraint(
+      articulatedObjectId, linkId, objectId, maxImpulse, pivotA, pivotB);
+}
+
+void Simulator::removeConstraint(int constraintId) {
+  physicsManager_->removeConstraint(constraintId);
 }
 
 // END: Articulated Object API (UNSTABLE!)

--- a/src/esp/sim/Simulator.h
+++ b/src/esp/sim/Simulator.h
@@ -762,6 +762,34 @@ class Simulator {
    */
   core::Random::ptr random() { return random_; }
 
+  void overrideCollisionGroup(int objectID, int group);
+
+  int createArticulatedP2PConstraint(int articulatedObjectId,
+                                     int linkId,
+                                     int objectId,
+                                     float maxImpulse);
+
+  int createArticulatedP2PConstraintWithPivots(int articulatedObjectId,
+                                               int linkId,
+                                               int objectId,
+                                               const Magnum::Vector3& pivotA,
+                                               const Magnum::Vector3& pivotB,
+                                               float maxImpulse);
+
+  int createArticulatedFixedConstraint(int articulatedObjectId,
+                                       int linkId,
+                                       int objectId,
+                                       float maxImpulse);
+
+  int createArticulatedFixedConstraintWithPivots(int articulatedObjectId,
+                                                 int linkId,
+                                                 int objectId,
+                                                 const Magnum::Vector3& pivotA,
+                                                 const Magnum::Vector3& pivotB,
+                                                 float maxImpulse);
+
+  void removeConstraint(int constraintId);
+
   int getPhysicsNumActiveContactPoints() {
     return physicsManager_->getNumActiveContactPoints();
   }


### PR DESCRIPTION
## Motivation and Context

Experimental support for:
- point2point and fixed constraints between articulated object link and rigid object
- overriding CollisionGroup for a rigid object so that you can disable collision between the object and the robot

This code is messy and probably not suitable for merging into Habitat master. I'm providing this to unblock Andrew's experiments in `p-viz-plan`.

See demo here: https://github.com/ASzot/p-viz-plan/pull/3

## How Has This Been Tested

Ad hoc testing in Viewer and `p-viz-plan orp/play.py`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
